### PR TITLE
Removed dimensionality from distributions

### DIFF
--- a/bin/ltl-fun-ce-gaussmix.py
+++ b/bin/ltl-fun-ce-gaussmix.py
@@ -77,7 +77,7 @@ def main():
     # TODO: Change the optimizer to the appropriate Optimizer class
     parameters = CrossEntropyParameters(pop_size=50, rho=0.2, smoothing=0.0, temp_decay=0, n_iteration=5,
                                         distribution=NoisyBayesianGaussianMixture(2,
-                                                                                  additive_noise=[1., 1.],
+                                                                                  noise_level=0.1,
                                                                                   noise_decay=0.9),
                                         stop_criterion=np.inf, seed=103)
     optimizer = CrossEntropyOptimizer(traj, optimizee_create_individual=optimizee.create_individual,

--- a/bin/ltl-fun-ce.py
+++ b/bin/ltl-fun-ce.py
@@ -73,7 +73,7 @@ def main():
     # NOTE: Outerloop optimizer initialization
     # TODO: Change the optimizer to the appropriate Optimizer class
     parameters = CrossEntropyParameters(pop_size=50, rho=0.2, smoothing=0.0, temp_decay=0, n_iteration=5,
-                                        distribution=NoisyGaussian(additive_noise=[1., 1.],
+                                        distribution=NoisyGaussian(noise_level=0.1,
                                                                    noise_decay=0.95),
                                         stop_criterion=np.inf, seed=102)
     optimizer = CrossEntropyOptimizer(traj, optimizee_create_individual=optimizee.create_individual,


### PR DESCRIPTION
Dimensionality dependence of cross entropy distributions should be removed by now.
Added an equivalent scalar noise parameter that works together with the variance obtained by the optimizee's create_individual.