### PR TITLE
BUGFIXED SCOOP to fix inefficient scheduling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy
 scipy
 pyyaml
 matplotlib
-git+https://github.com/IGITUGraz/scoop.git@53df7cc#egg=scoop-0.7.2.0-dev6
+git+https://github.com/IGITUGraz/scoop.git@863f46e#egg=scoop-0.7.2.0-dev7
 git+https://github.com/IGITUGraz/pypet.git@15104ce#egg=pypet-0.4.1-r1
 sphinx
 sklearn


### PR DESCRIPTION
There were some scheduling issues in scoop which was causing more than one task to be run on the source worker no matter how many workers were present. This lead to a doubling of the simulation time. This has now been fixed.